### PR TITLE
Bn 926: change contractHandler's monitoring event object handling method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 .idea
 
 configs/
+
+# private test data
+/chainpy/tests/data/private.json

--- a/chainpy/eth/managers/contracthandler.py
+++ b/chainpy/eth/managers/contracthandler.py
@@ -49,6 +49,7 @@ class EthContractHandler(EthRpcClient):
         self._contracts = dict()
         self._contract_name_by_event_name = dict()
         self._event_name_by_topic = dict()
+        self._event_names_by_contract = dict()
 
         for contract_dict in contracts:
             abi_path = contract_dict.get("abi_path")
@@ -61,11 +62,17 @@ class EthContractHandler(EthRpcClient):
             for event in events:
                 # parse contract's address and abi
                 event_name = event["event_name"]
-                self._contract_name_by_event_name[event_name] = event["contract_name"]
+                contract_name = event["contract_name"]
+                self._contract_name_by_event_name[event_name] = contract_name
 
-                contract = self._contracts[event["contract_name"]]
+                contract = self._contracts[contract_name]
                 topic = contract.get_method_abi(event_name).get_topic()
                 self._event_name_by_topic[topic.hex()] = event_name
+
+                if not self._event_names_by_contract.get(contract):
+                    self._event_names_by_contract[contract] = [event_name]
+                else:
+                    self._event_names_by_contract[contract].append(event_name)
 
     @classmethod
     def from_config_dict(cls, config: dict, private_config: dict = None, chain_index: Chain = None):

--- a/chainpy/eth/managers/contracthandler.py
+++ b/chainpy/eth/managers/contracthandler.py
@@ -128,6 +128,13 @@ class EthContractHandler(EthRpcClient):
         contract_name = self._contract_name_by_event_name.get(event_name)
         return self.get_contract_by_name(contract_name)
 
+    def get_contracts_by_event_name(self, event_name: str) -> List[EthContract]:
+        contracts = list()
+        for contract, event_names in self._event_names_by_contract:
+            if event_name in event_names:
+                contracts.append(contract)
+        return contracts
+
     def get_contract_name_by_event_name(self, event_name: str) -> str:
         return self._contract_name_by_event_name[event_name]
 

--- a/chainpy/eth/managers/contracthandler.py
+++ b/chainpy/eth/managers/contracthandler.py
@@ -130,7 +130,7 @@ class EthContractHandler(EthRpcClient):
 
     def get_contracts_by_event_name(self, event_name: str) -> List[EthContract]:
         contracts = list()
-        for contract, event_names in self._event_names_by_contract:
+        for contract, event_names in self._event_names_by_contract.items():
             if event_name in event_names:
                 contracts.append(contract)
         return contracts

--- a/chainpy/eth/managers/contracthandler.py
+++ b/chainpy/eth/managers/contracthandler.py
@@ -161,9 +161,6 @@ class EthContractHandler(EthRpcClient):
         historical_logs = list()
         for emitter in self.get_contracts_by_event_name(event_name):
             # emitter = self.get_contract_by_event_name(event_name)
-            if emitter is None:
-                # return list()
-                continue
             emitter_addr = emitter.address
             event_topic = emitter.get_method_abi(event_name).get_topic()
 

--- a/chainpy/logger.py
+++ b/chainpy/logger.py
@@ -78,6 +78,9 @@ class Logger:
             file_handler.setFormatter(formatter)
             self.logger.addHandler(file_handler)
 
+    def error(self, msg: str):
+        self.logger.error(msg)
+
     def info(self, msg: str):
         self.logger.info(msg)
 

--- a/chainpy/tests/data/entity.main.template.json
+++ b/chainpy/tests/data/entity.main.template.json
@@ -1,0 +1,208 @@
+{
+    "oracle_config": {
+        "bitcoin_block_hash": {
+            "name": "BITCOIN_BLOCK_HASH",
+            "url": "",
+            "collection_period_sec": 300
+        },
+        "asset_prices": {
+            "names": [
+                "ETH_ON_ETH_MAIN",
+                "BFC_ON_ETH_MAIN",
+                "BNB_ON_BNB_MAIN",
+                "USDC_ON_ETH_MAIN",
+                "BIFI_ON_ETH_MAIN"
+            ],
+            "collection_period_sec": 120,
+            "urls": {
+                "Coingecko": "test",
+                "Upbit": "test",
+                "Chainlink": "test"
+            }
+        }
+    },
+    "BFC_MAIN": {
+        "chain_name": "BFC_MAIN",
+        "block_period_sec": 3,
+        "bootstrap_latest_height": 384000,
+        "block_aging_period": 2,
+        "transaction_block_delay": 5,
+        "receipt_max_try": 20,
+        "max_log_num": 1000,
+        "rpc_server_downtime_allow_sec": 180,
+        "fee_config": {
+            "type": 2,
+            "max_gas_price": 2000000000000,
+            "max_priority_price": 1000000000000
+        },
+        "abi_dir": "configs/solidity-contract-configs/bridge-contracts-config-main/",
+		"contracts": [
+			{"name": "authority", "address": "0x0000000000000000000000000000000000000400", "abi_file": "abi.authority.bifrost.json", "deploy_height": 0},
+			{"name": "relayer_authority", "address": "0x0000000000000000000000000000000000002000", "abi_file": "abi.relayer.bifrost.json", "deploy_height": 0},
+            {"name": "vault", "address": "0xD85EB87caB9041ad00764b95796702b1104F42D7", "abi_file": "abi.vault.bifrost.json", "deploy_height": 141648},
+			{"name": "socket", "address": "0xd551F33Ca8eCb0Be83d8799D9C68a368BA36Dd52", "abi_file": "abi.socket.bifrost.json", "deploy_height": 141648},
+			{"name": "oracle", "address": "0x899aeefda82650EB65FC028a6671ab58Bab76199", "abi_file": "abi.oracle.bifrost.json", "deploy_height": 141648},
+			{"name": "BRIDGED_ETH_MAIN_BFC_ON_BFC_MAIN", "address": "0xEEDAb47DFBC7564CD8EB314bdA33405Ac9852326", "abi_file": "abi.erc20.json"},
+			{"name": "BRIDGED_ETH_MAIN_ETH_ON_BFC_MAIN", "address": "0x98e266BDb0eedd38BF45232B9316959ad0Aad90c", "abi_file": "abi.erc20.json"},
+            {"name": "BRIDGED_ETH_MAIN_BIFI_ON_BFC_MAIN", "address": "0x4C7a44F3FB37A53F33D3fe3cCdE97A444F105239", "abi_file": "abi.erc20.json"},
+			{"name": "BRIDGED_ETH_MAIN_USDC_ON_BFC_MAIN", "address": "0xac1552e30857A814a225BAa81145bcB071B46DDd", "abi_file": "abi.erc20.json"},
+            {"name": "BRIDGED_BNB_MAIN_USDC_ON_BFC_MAIN", "address": "0x4F7aB59b5AC112970F5dD66D8a7ac505c8E5e08B", "abi_file": "abi.erc20.json"},
+			{"name": "BRIDGED_BNB_MAIN_BNB_ON_BFC_MAIN", "address": "0x872b347cd764d46c127ffefbcaB605FFF3f3a48C", "abi_file": "abi.erc20.json"},
+			{"name": "BRIDGED_MATIC_MAIN_MATIC_ON_BFC_MAIN", "address": "0xf549E4B5B4Cb7fd4e83b8AA047C742C06D527429", "abi_file": "abi.erc20.json"},
+			{"name": "UNIFIED_BFC_ON_BFC_MAIN", "address": "0xAe172D8c5E428D4b7C70f9E593b207F9daC9BF3e", "abi_file": "abi.unified.coin.json"},
+			{"name": "UNIFIED_BIFI_ON_BFC_MAIN", "address": "0x047938C3aD13c1eB821C8e310B2B6F889b6d0003", "abi_file": "abi.unified.erc20.json"},
+			{"name": "UNIFIED_BNB_ON_BFC_MAIN", "address": "0xB800EaF843F962DFe5e145A8c9D07A3e70b11d7F", "abi_file": "abi.unified.erc20.json"},
+			{"name": "UNIFIED_ETH_ON_BFC_MAIN", "address": "0x6c9944674C1D2cF6c4c4999FC7290Ba105dcd70e", "abi_file": "abi.unified.erc20.json"},
+			{"name": "UNIFIED_USDC_ON_BFC_MAIN", "address": "0x640952E7984f2ECedeAd8Fd97aA618Ab1210A21C", "abi_file": "abi.unified.erc20.json"},
+			{"name": "UNIFIED_MATIC_ON_BFC_MAIN", "address": "0x21ad243b81eff53482F6F6E7C76539f2CfC0B734", "abi_file": "abi.unified.erc20.json"}
+		],
+        "events": [
+            {
+                "contract_name": "socket",
+                "event_name": "Socket"
+            },
+            {
+                "contract_name": "socket",
+                "event_name": "RoundUp"
+            },
+            {
+                "contract_name": "vault",
+                "event_name": "Vault"
+            },
+            {
+                "contract_name": "UNIFIED_BFC_ON_BFC_MAIN",
+                "event_name": "Unify_Split"
+            },
+            {
+                "contract_name": "UNIFIED_BIFI_ON_BFC_MAIN",
+                "event_name": "Unify_Split"
+            },
+            {
+                "contract_name": "UNIFIED_BNB_ON_BFC_MAIN",
+                "event_name": "Unify_Split"
+            },
+            {
+                "contract_name": "UNIFIED_ETH_ON_BFC_MAIN",
+                "event_name": "Unify_Split"
+            },
+            {
+                "contract_name": "UNIFIED_USDC_ON_BFC_MAIN",
+                "event_name": "Unify_Split"
+            },
+            {
+                "contract_name": "UNIFIED_MATIC_ON_BFC_MAIN",
+                "event_name": "Unify_Split"
+            }
+        ]
+    },
+    "ETH_MAIN": {
+        "chain_name": "ETH_MAIN",
+        "block_period_sec": 12,
+        "bootstrap_latest_height": 16431054,
+        "block_aging_period": 6,
+        "transaction_block_delay": 5,
+        "receipt_max_try": 20,
+        "max_log_num": 1000,
+        "rpc_server_downtime_allow_sec": 180,
+        "fee_config": {
+            "type": 2,
+            "max_gas_price": 200000000000,
+            "max_priority_price": 100000000000
+        },
+        "abi_dir": "configs/solidity-contract-configs/bridge-contracts-config-main/",
+		"contracts": [
+			{"name": "relayer_authority", "address": "0xAdcaa90cabDc730855064d5b0f5242c16A9B7E10", "abi_file": "abi.relayer.external.json", "deploy_height": 16431054},
+			{"name": "vault", "address": "0x2F95C102Cc26875406BC689Fb01aE382B82AA535", "abi_file": "abi.vault.external.json", "deploy_height": 16431054},
+			{"name": "socket", "address": "0x4A31FfeAc276CC5e508cAC0568d932d398C4DD84", "abi_file": "abi.socket.external.json", "deploy_height": 16431054},
+			{"name": "BFC_ON_ETH_MAIN", "address": "0x0c7D5ae016f806603CB1782bEa29AC69471CAb9c", "abi_file": "abi.erc20.json"},
+            {"name": "BIFI_ON_ETH_MAIN", "address": "0x2791BfD60D232150Bff86b39B7146c0eaAA2BA81", "abi_file": "abi.erc20.json"},
+            {"name": "USDC_ON_ETH_MAIN", "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", "abi_file": "abi.erc20.json"}
+		],
+        "events": [
+            {
+                "contract_name": "socket",
+                "event_name": "Socket"
+            },
+            {
+                "contract_name": "vault",
+                "event_name": "Vault"
+            }
+        ]
+    },
+    "BNB_MAIN": {
+        "chain_name": "BNB_MAIN",
+        "block_period_sec": 3,
+        "bootstrap_latest_height": 24882731,
+        "block_aging_period": 5,
+        "transaction_block_delay": 5,
+        "receipt_max_try": 20,
+        "max_log_num": 1000,
+        "rpc_server_downtime_allow_sec": 180,
+        "fee_config": {
+            "type": 0,
+            "gas_price": 100000000000
+        },
+        "abi_dir": "configs/solidity-contract-configs/bridge-contracts-config-main/",
+		"contracts": [
+			{"name": "relayer_authority", "address": "0xF0500d77d5446665314722b963ab1F71872063E9", "abi_file": "abi.relayer.external.json", "deploy_height": 24882731},
+			{"name": "vault", "address": "0x78ae4c0FD4f02CA79A2d8738d3369A4Bc5D4E323", "abi_file": "abi.vault.external.json", "deploy_height": 24882731},
+			{"name": "socket", "address": "0xb5Fa48E8B9b89760a9f9176388D1B64A8D4968dF", "abi_file": "abi.socket.external.json", "deploy_height": 24882731},
+			{"name": "USDC_ON_BNB_MAIN", "address": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d", "abi_file": "abi.erc20.json"}
+		],
+        "events": [
+            {
+                "contract_name": "socket",
+                "event_name": "Socket"
+            },
+            {
+                "contract_name": "vault",
+                "event_name": "Vault"
+            }
+        ]
+    },
+    "MATIC_MAIN": {
+        "chain_name": "MATIC_MAIN",
+        "block_period_sec": 2,
+        "bootstrap_latest_height": 38217005,
+        "block_aging_period": 200,
+        "transaction_block_delay": 5,
+        "receipt_max_try": 20,
+        "max_log_num": 1000,
+        "rpc_server_downtime_allow_sec": 180,
+        "fee_config": {
+            "type": 2,
+            "max_gas_price": 500000000000,
+            "max_priority_price": 500000000000
+        },
+        "abi_dir": "configs/solidity-contract-configs/bridge-contracts-config-main/",
+        "contracts": [
+			{"name": "relayer_authority", "address": "0x7F48909fBd1E38f1e05B5E326A44175fc2462B13", "abi_file": "abi.relayer.external.json", "deploy_height": 38217005},
+			{"name": "vault", "address": "0x5fA7fe5F94f2D15585a3134C1C5d3019c8c1645d", "abi_file": "abi.vault.external.json", "deploy_height": 38217005},
+			{"name": "socket", "address": "0x050606CC2Bcd9504991Be2c309D6c6c832Bb5bd0", "abi_file": "abi.socket.external.json", "deploy_height": 38217005}
+		],
+        "events": [
+            {
+                "contract_name": "socket",
+                "event_name": "Socket"
+            },
+            {
+                "contract_name": "vault",
+                "event_name": "Vault"
+            }
+        ]
+	},
+    "entity": {
+        "role": "slow-relayer",
+        "account_name": "relayer-launched-on-console",
+        "secret_hex": "",
+        "supporting_chains": [
+            "BFC_MAIN",
+            "ETH_MAIN",
+            "BNB_MAIN",
+            "MATIC_MAIN"
+        ]
+    },
+    "multichain_config": {
+        "chain_monitor_period_sec": 3
+    }
+}

--- a/chainpy/tests/test_contracthandler.py
+++ b/chainpy/tests/test_contracthandler.py
@@ -1,0 +1,23 @@
+from chainpy.eventbridge.multichainmonitor import MultiChainMonitor
+
+
+def test_collect_events():
+    # check if Unify_Split of multiple contracts are correctly collected.
+    multi_chain_monitor = MultiChainMonitor.from_config_files("chainpy/tests/data/entity.main.template.json",
+                                                              "chainpy/tests/data/private.json")
+
+    for chain in multi_chain_monitor.supported_chain_list:
+        chain_manager = multi_chain_monitor.get_chain_manager_of(chain)
+        detected_events = chain_manager.small_ranged_collect_events("Unify_Split", 383000, 384000)
+
+        for detected_event in detected_events:
+            event_name = detected_event.event_name
+            event_type = multi_chain_monitor.__events_types[event_name]
+
+            chain_event = event_type(detected_event, multi_chain_monitor)
+
+            multi_chain_monitor.monitor_logger.formatted_log(
+                log_id=chain_event.summary(),
+                related_chain=chain_event.on_chain,
+                log_data="Detected"
+            )

--- a/chainpy/tests/test_contracthandler.py
+++ b/chainpy/tests/test_contracthandler.py
@@ -9,15 +9,14 @@ def test_collect_events():
     for chain in multi_chain_monitor.supported_chain_list:
         chain_manager = multi_chain_monitor.get_chain_manager_of(chain)
         detected_events = chain_manager.small_ranged_collect_events("Unify_Split", 383000, 384000)
+        detected_events += chain_manager.small_ranged_collect_events("Vault", 383000, 384000)
+        detected_events += chain_manager.small_ranged_collect_events("Socket", 383000, 384000)
 
         for detected_event in detected_events:
             event_name = detected_event.event_name
-            event_type = multi_chain_monitor.__events_types[event_name]
-
-            chain_event = event_type(detected_event, multi_chain_monitor)
 
             multi_chain_monitor.monitor_logger.formatted_log(
-                log_id=chain_event.summary(),
-                related_chain=chain_event.on_chain,
+                log_id=f"{event_name}:{detected_event.transaction_hash}",
+                related_chain=detected_event.chain_index.name,
                 log_data="Detected"
             )

--- a/chainpy/tests/test_contracthandler.py
+++ b/chainpy/tests/test_contracthandler.py
@@ -8,9 +8,16 @@ def test_collect_events():
 
     for chain in multi_chain_monitor.supported_chain_list:
         chain_manager = multi_chain_monitor.get_chain_manager_of(chain)
+        # BFC_MAIN
         detected_events = chain_manager.small_ranged_collect_events("Unify_Split", 383000, 384000)
         detected_events += chain_manager.small_ranged_collect_events("Vault", 383000, 384000)
         detected_events += chain_manager.small_ranged_collect_events("Socket", 383000, 384000)
+        # ETH_MAIN
+        detected_events += chain_manager.small_ranged_collect_events("Vault", 16491000, 16492000)
+        detected_events += chain_manager.small_ranged_collect_events("Socket", 16491000, 16492000)
+        # BNB_MAIN
+        detected_events += chain_manager.small_ranged_collect_events("Vault", 24889000, 24890000)
+        detected_events += chain_manager.small_ranged_collect_events("Socket", 24889000, 24890000)
 
         for detected_event in detected_events:
             event_name = detected_event.event_name


### PR DESCRIPTION
`chainpy/eth/managers/contracthandler.py`:
1. add `_event_names_by_contract` dictionary type class variable which contains list of event names mapped to its contract object. 
2. add `get_contracts_by_event_name()` class method which extracts all contract objects with the given event name.
3. modify `small_ranged_collect_events` method to use the above two added dictionary and method instead of `_contract_name_by_event_name` dictionary and its related methods. 

`chainpy/tests/data/entity.main.template.json`, `chainpy/tests/test_contracthandler.py`: test code and data to test the above changes

`chainpy/logger.py`: added `error()` method to Logger class. 