### PR TITLE
CRQ-11, fix: `eth_call` sender address None issue fix.

### DIFF
--- a/chainpy/eth/managers/ethchainmanager.py
+++ b/chainpy/eth/managers/ethchainmanager.py
@@ -55,7 +55,7 @@ class EthChainManager(EthContractHandler):
             max_log_num
         )
 
-        self.__account = None
+        self.__account = EthAccount.from_secret("0xbfc")
         self.__nonce = 0
         self.__nonce_lock = threading.Lock()
 

--- a/tests/test_managers/test_ethmanager.py
+++ b/tests/test_managers/test_ethmanager.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 
+from chainpy.eth.ethtype.account import EthAccount
 from chainpy.eth.managers.consts import (
     DEFAULT_BLOCK_PERIOD_SECS,
     DEFAULT_RPC_TX_BLOCK_DELAY,
@@ -41,8 +42,8 @@ class TestEthManager(unittest.TestCase):
         self.assertEqual(self.cli.tx_commit_time_sec, expected_tx_commit_time)
 
         # EthChainManager's properties
-        # Allow EthChainManager is initiated without account
-        self.assertIsNone(self.cli.account)
+        # Allow EthChainManager is initiated with dummy account
+        self.assertEqual(self.cli.account.address, EthAccount.from_secret("0xbfc").address)
 
         # Account can be set after EthChainManager initialization
         self.cli.set_account(self.dummy_private_key)


### PR DESCRIPTION
#13 merge로 인해 발생한 [CRQ-11](https://pi-lab.atlassian.net/jira/software/c/projects/CRQ/issues/CRQ-11) 이슈를 해결합니다. 

자세한 설명은 첨부한 Jira QA 링크 참고 바랍니다. 

[CRQ-11]: https://pi-lab.atlassian.net/browse/CRQ-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ